### PR TITLE
Setting seed for random in addition to numpy and torch

### DIFF
--- a/fastssl/utils/base.py
+++ b/fastssl/utils/base.py
@@ -1,12 +1,17 @@
 from argparse import ArgumentParser
+import random, os
 import torch
 import numpy as np
 
 from fastargs import get_current_config
 
-def set_seeds(seed):
+def set_seeds(seed, use_deterministic=False):
+    random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+    if use_deterministic:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        torch.use_deterministic_algorithms(True)
 
 
 def get_args_from_config():

--- a/sbatch_sh_files/verify_barlowTwins.sh
+++ b/sbatch_sh_files/verify_barlowTwins.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+####SBATCH --array=0-47%16
+#SBATCH --partition=long
+#SBATCH --gres=gpu:a100:1
+#SBATCH --reservation=DGXA100
+#SBATCH --mem=16GB
+#SBATCH --time=4:00:00
+#SBATCH --cpus-per-gpu=4
+#SBATCH --output=sbatch_out/exp_track_alpha_barlowtwins.out
+#SBATCH --error=sbatch_err/exp_track_alpha_barlowtwins.err
+#SBATCH --job-name=exp_track_alpha_barlowtwins
+
+. /etc/profile
+module load anaconda/3
+conda activate ffcv
+
+lambd=0.00397897
+pdim=3072
+dataset='cifar10'
+if [ $dataset = 'stl10' ]
+then
+    batch_size=256
+else
+    batch_size=512
+fi
+
+checkpt_dir=$SCRATCH/fastssl/checkpoints
+
+python scripts/train_model.py --config-file configs/cc_barlow_twins.yaml --training.lambd=$lambd --training.projector_dim=$pdim --training.dataset=$dataset --training.ckpt_dir=$checkpt_dir --training.batch_size=$batch_size --training.track_alpha=True --training.log_interval=2
+python scripts/train_model.py --config-file configs/cc_classifier.yaml --training.lambd=$lambd --training.projector_dim=$pdim --training.dataset=$dataset --training.ckpt_dir=$checkpt_dir --training.seed=1
+python scripts/train_model.py --config-file configs/cc_classifier.yaml --training.lambd=$lambd --training.projector_dim=$pdim --training.dataset=$dataset --training.ckpt_dir=$checkpt_dir --training.seed=2
+python scripts/train_model.py --config-file configs/cc_classifier.yaml --training.lambd=$lambd --training.projector_dim=$pdim --training.dataset=$dataset --training.ckpt_dir=$checkpt_dir --training.seed=3
+# dataset='stl10'
+
+cp $SLURM_TMPDIR/*.pth $checkpt_dir/resnet50_checkpoints/


### PR DESCRIPTION
**Summary of changes**
1. Updated `set_seeds` function to set the seed for `random` and tried using torch deterministic algorithms for reproducibility: Note that this did not improve reproducibility of numbers because ffcv with multiple workers is the primary reason for variability. In future experiments, we should run SSL training for 3 seeds and simultaneously train linear eval for each SSL model to average over variability.
2. Added `sbatch_sh_files/verify_barlowtwins.sh`: Added a simple script file to run BarlowTwins training for ResNet-50 backbone with the best hyperparameters for Cifar-10. This should enable easy experiments and testing in the future.