### PR TITLE
Merge changes from main to modelScale branch

### DIFF
--- a/sbatch_sh_files/resnet50_barlow_sweep.sh
+++ b/sbatch_sh_files/resnet50_barlow_sweep.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-#SBATCH --array=0-119%25
+#SBATCH --array=0-119%20
 #SBATCH --partition=long
 #SBATCH --gres=gpu:rtx8000:1
 #SBATCH --mem=16GB
 #SBATCH --time=4:00:00
 #SBATCH --cpus-per-gpu=4
-#SBATCH --output=sbatch_out/resnet18_barlowtwins.%A.%a.out
-#SBATCH --error=sbatch_err/resnet18_barlowtwins.%A.%a.err
-#SBATCH --job-name=resnet18_barlowtwins
+#SBATCH --output=sbatch_out/resnet50_barlowtwins.%A.%a.out
+#SBATCH --error=sbatch_err/resnet50_barlowtwins.%A.%a.err
+#SBATCH --job-name=resnet50_barlowtwins
 
 . /etc/profile
 module load anaconda/3
@@ -30,10 +30,10 @@ lambd=${lambd_arr[$lidx]}
 pdim=${pdim_arr[$pidx]}
 
 wandb_group='blake-richards'
-wandb_projname='BarlowTwins-resnet18-hparam'
+wandb_projname='BarlowTwins-resnet50-hparam'
 
 width=64
-model=resnet18proj_width${width}
+model=resnet50proj_width${width}
 checkpt_dir=$SCRATCH/fastssl/checkpoints_matteo
 
 
@@ -45,7 +45,7 @@ python scripts/train_model_widthVary.py --config-file configs/cc_barlow_twins.ya
                 --logging.use_wandb=True --logging.wandb_group=$wandb_group \
                 --logging.wandb_project=$wandb_projname
 
-model=resnet18feat_width${width}
+model=resnet50feat_width${width}
 # Let's precache features, should take ~35 seconds (rtx8000)
 python scripts/train_model_widthVary.py --config-file configs/cc_precache.yaml \
                 --training.lambd=$lambd --training.projector_dim=$pdim \
@@ -63,4 +63,4 @@ python scripts/train_model_widthVary.py --config-file configs/cc_classifier.yaml
 
 # dataset='stl10'
 
-# cp $SLURM_TMPDIR/*.pth $checkpt_dir/resnet18_checkpoints/
+# cp $SLURM_TMPDIR/*.pth $checkpt_dir/resnet50_checkpoints/


### PR DESCRIPTION
* Adding quick and dirty implementation of adaptive lambda for BarlowTwins

* Adding a plotting script to plot results with adaptive Lambda

* Pushing the most recent sbatch script with 10 sweeps of lambda and flag to run adaptive or not

* Updating plot_adaptive_track_alpha script to support multiple seeds of SSL training

* Making minor changes to plotting file to choose when to use old_alpha

* Changing sbatch file to running seeds as separate jobs (ran jobs for STL10)

* Adding recent changes to plotting code

* Adding a test ffcv loader to check multi-augmentation generation with original image (Issue #31)

* Minor temporary changes to test multi-augmentation feature -- changes will be reverted eventually after Issue #31 is resovled

* Adding tqdm while passing over dataset

* Changed ffcv_ssl image label pipeline to enable multiple augmentations (Issue #31)

* Modified BarlowTwins loss to support multi-augmentation pipeline (Issue #31)

* Updating SimCLR loss computation for multiple patches (Issue #31)

* Adding multipatch feature to dataloader for linear classification for Cifar (Issue #31)

* Adding num_augmentations to the argument list and updating model forward pass during linear probing and precaching (Issue #31)

* Adding the new arguments of num_augmentations to config files (Issue #31)

* Updating folder naming while saving results to indicate pretraining num_augmentations and eval num_augmentations (Issue #31)

* Changing linear model forward pass to fit with multiple augmentation eval setting (Issue #31)

* Fixing bugs in linear eval pipeline for multi-augmentation eval (Issue #31)

* Fixing directory name for saving linear eval results with multiple augs (Issue #31)

* Fixing precaching mean over augs operation (Issue #31)

* basic formatting

* Fixing minor errors in multi-patch SimCLR implementation (Issue #31)

* Adding condition to check if None is passed for train or val dataset

* Updating SimCLR config yaml and adding script to verify SimCLR run

* Adding new changes to verify_simclr.sh -- Still need to debug simclr implementation

* Adding model base width parameter to control resnet18 base width while sweeping across different model widths (Issue #34)

* Adding script files for resnet18 hparam search and varying width sweeps (Issue #34)

* Adding training script with new model width argument (Issue #34)

* Extracting base width from model name instead of passing separate argument from cmd line (Issue #34)

* Enabling wandb logging for widthVary experiments (Issue #34)

* Adding eval on train set to report train set accuracy (Issue #34)

* Putting precached features under feats subdir in SLURM_TMPDIR

* Copying precached features to checkpt_dir (Issue #34)

* Assigning correct wandb project name for Noise 15 case (Issue #34)

* Changing jobtype description on wandb to indicate pretraining algorithm while running linear eval jobs (Issue #34)

* Enabling simultaneous eval for Noise 0 and Noise 15 with one SSL pretraining (Issue #34)

* Adding Resnet50 width variation and moving resnet functions to separate file instead of backbone.py (Issue #34)

* merging experiments for noise and no noise linear eval into one script

* Adding option to vary width for Resnet50 (Issue #34)

* Adding WANDB service wait to avoid wandb init errors while launching array jobs

* Adding sbatch script for resnet50 hparam sweep

* Correcting env name in bash script

* Updating resnet barlow sweep files

* Updating the sbatch script files for hparam sweep

---------